### PR TITLE
Add Session Feedback section to nimblebrain-contributor and build-mcpb

### DIFF
--- a/build-mcpb/SKILL.md
+++ b/build-mcpb/SKILL.md
@@ -318,3 +318,53 @@ See `references/` in this skill for:
 ## Templates
 
 Read templates from `templates/` directory in this skill folder. See the directory listing for all available templates.
+
+## Session Feedback
+
+After completing the build pipeline (or if the session ends early), offer to send structured feedback:
+
+> "Would you like to send a summary of this session as feedback to NimbleBrain? This helps improve the skills for future contributors."
+
+**If the user says yes**, file a feedback issue:
+
+```bash
+gh issue create --repo NimbleBrainInc/hq \
+  --title "Skill Feedback: build-mcpb (<server name>)" \
+  --label "skill-feedback" \
+  --body "## Session Summary
+- **Server built:** <server name>
+- **API wrapped:** <service name>
+- **Platform:** <OS, shell, tool versions>
+- **Outcome:** <success / partial / blocked>
+
+## Phase-by-Phase Walkthrough
+
+| Phase | Description | Result |
+|-------|-------------|--------|
+| 1. API Analysis | Fetch docs, identify resources, propose tools | ✅ Worked / ⚠️ Friction / ❌ Broke |
+| 2. Scaffold | Generate project structure | ✅ / ⚠️ / ❌ |
+| 3. Implement | Write tool logic, models, client | ✅ / ⚠️ / ❌ |
+| 4. Verify | Lint, typecheck, test | ✅ / ⚠️ / ❌ |
+| 5. Validate Bundle | Manifest, build, bundle, MTF, runtime | ✅ / ⚠️ / ❌ |
+| 6. Author Skills | Generate companion skills | ✅ / ⚠️ / ❌ |
+| 7. Prepare PR | Assemble PR with server + skills | ✅ / ⚠️ / ❌ |
+
+## Friction / Breakage Details
+<For any phase flagged ⚠️ or ❌, describe what happened>
+
+## Suggested Fixes
+<Concrete suggestions for improving the skill>
+
+## Summary
+| Metric | Value |
+|--------|-------|
+| Phases completed | X / 7 |
+| Friction points | X |
+| Blockers | X |
+| Overall | ✅ Smooth / ⚠️ Usable / ❌ Blocked |
+"
+```
+
+Fill in each field based on what actually happened during the session. Flag each phase honestly.
+
+**If the user says no**, skip silently and do not ask again.

--- a/nimblebrain-contributor/SKILL.md
+++ b/nimblebrain-contributor/SKILL.md
@@ -214,6 +214,53 @@ gh issue list --repo NimbleBrainInc/hq --assignee @me
 - **Docs:** docs.nimblebrain.ai
 - **MCP spec:** modelcontextprotocol.io
 
+## Session Feedback
+
+After completing any workflow above (onboarding, picking work, filing an issue, or handing off to `/build-mcpb`), offer to send structured feedback:
+
+> "Would you like to send a summary of this session as feedback to NimbleBrain? This helps improve the skills for future contributors."
+
+**If the user says yes**, file a feedback issue:
+
+```bash
+gh issue create --repo NimbleBrainInc/hq \
+  --title "Skill Feedback: nimblebrain-contributor (<what was done>)" \
+  --label "skill-feedback" \
+  --body "## Session Summary
+- **What was done:** <brief description>
+- **Platform:** <OS, shell, tool versions>
+- **Outcome:** <success / partial / blocked>
+
+## Step-by-Step Walkthrough
+
+| Step | Description | Result |
+|------|-------------|--------|
+| 1. Check Environment | Verify tools installed | ✅ Worked / ⚠️ Friction / ❌ Broke |
+| 2. Check Required Skills | Verify build-mcpb installed | ✅ / ⚠️ / ❌ |
+| 3. Orient | Explain NimbleBrain contributions | ✅ / ⚠️ / ❌ |
+| 4. Help Pick Work | Browse issues, pick integration | ✅ / ⚠️ / ❌ |
+| 5. Get Started | Create repo, hand off to build | ✅ / ⚠️ / ❌ |
+
+## Friction / Breakage Details
+<For any step flagged ⚠️ or ❌, describe what happened>
+
+## Suggested Fixes
+<Concrete suggestions for improving the skill>
+
+## Summary
+| Metric | Value |
+|--------|-------|
+| Steps completed | X / 5 |
+| Friction points | X |
+| Blockers | X |
+| Overall | ✅ Smooth / ⚠️ Usable / ❌ Blocked |
+"
+```
+
+Fill in each field based on what actually happened during the session. Flag each step honestly.
+
+**If the user says no**, skip silently and do not ask again.
+
 ## References
 
 See `references/` in this skill for:


### PR DESCRIPTION
## Summary

- Adds a `## Session Feedback` section to both `nimblebrain-contributor` and `build-mcpb` skills
- After completing a workflow, the agent offers to file a structured feedback issue to `NimbleBrainInc/hq`
- Each issue includes a step/phase-by-phase walkthrough with ✅/⚠️/❌ flags, friction details, suggested fixes, and a summary table

## Motivation

After a full onboarding + Stripe MCP server build, we manually filed structured feedback (NimbleBrainInc/.github#3). This PR bakes that feedback loop directly into both skills so every contributor session can surface friction points automatically — no manual effort required.

## Changes

- **`nimblebrain-contributor/SKILL.md`** — New `## Session Feedback` section after "Key Links", before "References". Walks through Steps 1–5.
- **`build-mcpb/SKILL.md`** — New `## Session Feedback` section appended after "Templates". Walks through Phases 1–7.

## Test plan

- [ ] Read both modified SKILL.md files and confirm new sections render correctly
- [ ] Verify frontmatter and existing sections are untouched
- [ ] Confirm feedback issue template includes all steps/phases from each skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)