### PR TITLE
Add .gitignore fallback and fix CI validation trigger

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,8 @@ name: Validate Skills
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   validate:

--- a/build-mcpb/SKILL.md
+++ b/build-mcpb/SKILL.md
@@ -247,6 +247,7 @@ Phase 0 created the repo from template and customized all placeholders. Verify i
 - `tests/`
 - `manifest.json`, `server.json`, `pyproject.toml`, `Makefile`
 - `.github/workflows/ci.yml`, `.github/workflows/build-bundle.yml`
+- `.gitignore`, `.mcpbignore`
 
 **TypeScript** — check that these exist:
 - `src/index.ts`, `config.ts`, `constants.ts`, `types.ts`, `schemas.ts`, `formatters.ts`
@@ -254,8 +255,11 @@ Phase 0 created the repo from template and customized all placeholders. Verify i
 - `tests/`
 - `manifest.json`, `server.json`, `package.json`, `tsconfig.json`, `Makefile`
 - `.github/workflows/ci.yml`, `.github/workflows/build-bundle.yml`
+- `.gitignore`, `.mcpbignore`
 
 If any files are missing, create them following the patterns in `references/PATTERNS.md`.
+
+> **Fallback:** If `.gitignore` is missing (e.g., manual repo without template), generate it using the canonical content from `references/PATTERNS.md`. This prevents build artifacts (`bundle/`, `deps/`, `*.mcpb`), scanner reports, and secrets from being committed.
 
 See `references/PATTERNS.md` for full directory structure reference.
 

--- a/build-mcpb/references/PATTERNS.md
+++ b/build-mcpb/references/PATTERNS.md
@@ -31,6 +31,76 @@
 └── README.md
 ```
 
+### .gitignore (Python)
+
+```
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+build/
+dist/
+*.egg-info/
+.Python
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# Type checking
+.mypy_cache/
+.dmypy.json
+.pytype/
+
+# Linting
+.ruff_cache/
+
+# IDEs
+.idea/
+.vscode/
+*.code-workspace
+
+# OS
+.DS_Store
+Thumbs.db
+
+# MCP/Claude
+.claude/
+
+# Package managers
+uv.lock
+.uv/
+poetry.lock
+Pipfile.lock
+
+# Secrets
+*.key
+*.pem
+credentials.json
+.secrets/
+
+# Local development
+test_quick.py
+
+# MCPB bundles
+bundle/
+deps/
+*.mcpb
+
+# Scanner reports
+security-report.json
+```
+
 ### pyproject.toml
 
 ```toml
@@ -488,6 +558,58 @@ make bundle                          # Vendor deps + mcpb pack (local bundle)
 ├── server.json               # Registry metadata
 ├── tsconfig.json
 └── vitest.config.ts
+```
+
+### .gitignore (TypeScript)
+
+```
+# Node
+node_modules/
+build/
+dist/
+*.tgz
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# IDEs
+.vscode/
+.idea/
+*.code-workspace
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Claude
+.claude/
+
+# Testing
+coverage/
+.nyc_output/
+
+# MCPB bundles
+bundle/
+deps/
+*.mcpb
+
+# Scanner reports
+security-report.json
+.scan-results.json
+
+# Secrets
+*.key
+*.pem
+credentials.json
+.secrets/
+
+# Temp files
+tmp/
+temp/
+*.tmp
+*.swp
 ```
 
 ### Implementation Order


### PR DESCRIPTION
## Summary
- Add `.gitignore` and `.mcpbignore` to Phase 2 scaffold verification checklists (Python + TypeScript)
- Add fallback note: if `.gitignore` is missing (manual repo, no template), generate from canonical reference
- Add canonical `.gitignore` content for both languages in `PATTERNS.md`
- Add `pull_request` trigger to `validate.yml` — was push-only, so schema validation failures went undetected until after merge

## Test plan
- [x] Verify `validate.yml` triggers on PRs
- [x] Confirm PATTERNS.md `.gitignore` content matches actual templates
- [x] Note: `validate.sh` will still fail until NimbleBrainInc/mpak#23 merges (adds `version` to skill schema)