### PR TITLE
Edit PATTERNS.md to remove the skip on mpak-scanner installation on CI workflow

### DIFF
--- a/build-mcpb/references/PATTERNS.md
+++ b/build-mcpb/references/PATTERNS.md
@@ -463,9 +463,7 @@ jobs:
       - name: Build bundle
         run: npx @anthropic-ai/mcpb pack
       - name: Run MTF scanner
-        run: |
-          uv pip install mpak-scanner
-          mpak-scanner scan *.mcpb --json > scan-results.json
+        run: uvx mpak-scanner scan *.mcpb --json > scan-results.json
       - name: Check for critical/high findings
         run: |
           python3 -c "


### PR DESCRIPTION
The CI/CD workflow is passing the security check without scanning. This PR fixes it on the PATTERNS.md side (needs to be addressed in the Python MCP template as well).  