### PR TITLE
fix: update CLAUDE.md to match actual project structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,19 +7,21 @@ Installable skill pack for NimbleBrain open source contributors. Published to mp
 ```
 nimblebrain-contributor/     # Onboarding, coordination, HQ interaction
 ├── SKILL.md
+├── CHANGELOG.md
 ├── version.txt
 └── references/
     ├── DEV_SETUP.md
-    └── PIPELINE.md
+    ├── ECOSYSTEM.md
+    └── RESOURCES.md
 
 build-mcpb/                  # Full MCP server build pipeline
 ├── SKILL.md
+├── CHANGELOG.md
 ├── version.txt
-├── references/
-│   ├── CONVENTIONS.md
-│   ├── PATTERNS.md
-│   └── SKILL_FORMAT.md
-└── templates/               # 16 project scaffold templates
+└── references/
+    ├── CONVENTIONS.md
+    ├── PATTERNS.md
+    └── SKILL_FORMAT.md
 ```
 
 ## Versioning


### PR DESCRIPTION
## Summary

- **nimblebrain-contributor/references/**: replaced outdated `PIPELINE.md` with actual `ECOSYSTEM.md` and `RESOURCES.md`
- **build-mcpb/**: removed `templates/` directory reference (was removed in a5134f9)
- Added `CHANGELOG.md` entries to both skill directory trees

The structure section was stale, causing agents that load CLAUDE.md to give outdated information about the project layout.

## Test plan

- [ ] Verify the file tree in CLAUDE.md matches `find . -type f` output
- [ ] Run `./scripts/validate.sh`