### PR TITLE
docs(build-mcpb): remove redundant Quick Start section

### DIFF
--- a/build-mcpb/SKILL.md
+++ b/build-mcpb/SKILL.md
@@ -51,10 +51,6 @@ metadata:
 
 Build MCP servers end-to-end: scaffold from API docs, implement tools, validate the bundle, create an embedded skill resource, and release to the mpak registry. Supports Python (FastMCP) and TypeScript (@modelcontextprotocol/sdk).
 
-## Quick Start
-
-> /build-mcpb
-
 ## Pipeline
 
 Work through each phase in order. Read the linked workflow file for detailed instructions. Each phase has a gate that must pass before proceeding.


### PR DESCRIPTION
The Quick Start section only contained `> /build-mcpb` — the invocation command for the skill. Since every skill is invocable as `/<skill-name>`, this conveyed no information beyond universal skill invocation conventions and was pure noise.

closes https://github.com/NimbleBrainInc/contributor-toolkit/issues/42