### PR TITLE
fix(build-mcpb): allow mixed-case owner names in name regex

### DIFF
--- a/build-mcpb/references/CONVENTIONS.md
+++ b/build-mcpb/references/CONVENTIONS.md
@@ -4,9 +4,11 @@
 
 Package names MUST be scoped: `@<github_owner>/<name>`
 
-Name must match the registry regex: `/^@[a-z0-9][a-z0-9-]{0,38}\/[a-z0-9][a-z0-9-]{0,213}$/`
+Name must match the registry regex: `/^@[a-zA-Z0-9][a-zA-Z0-9-]{0,38}\/[a-z0-9][a-z0-9-]{0,213}$/`
 
-Registry rejects other formats (e.g., `ai.nimbletools/name`, uppercase, underscores in name).
+The owner segment (before `/`) accepts mixed case — the registry normalizes it to lowercase. The package name (after `/`) must be lowercase.
+
+Registry rejects other formats (e.g., `ai.nimbletools/name`, underscores in name).
 
 ## Naming
 
@@ -23,7 +25,7 @@ Registry rejects other formats (e.g., `ai.nimbletools/name`, uppercase, undersco
 
 | Field | Required | Notes |
 |-------|----------|-------|
-| `name` | **Yes** | Must match `/^@[a-z0-9][a-z0-9-]{0,38}\/[a-z0-9][a-z0-9-]{0,213}$/` |
+| `name` | **Yes** | Must match `/^@[a-zA-Z0-9][a-zA-Z0-9-]{0,38}\/[a-z0-9][a-z0-9-]{0,213}$/` |
 | `version` | **Yes** | Valid semver (e.g., `0.1.0`) |
 | `description` | **Yes** | Short description |
 | `server.type` | **Yes** | `python`, `node`, or `binary` |

--- a/build-mcpb/references/workflow/phase-4-validate-bundle.md
+++ b/build-mcpb/references/workflow/phase-4-validate-bundle.md
@@ -8,7 +8,7 @@ Check `manifest.json` against the mpak registry schema. See `references/CONVENTI
 
 **Registry validation checklist** (read `manifest.json` and verify each):
 
-1. **Name format** — must match `/^@[a-z0-9][a-z0-9-]{0,38}\/[a-z0-9][a-z0-9-]{0,213}$/` (e.g., `@<github_owner>/stripe`)
+1. **Name format** — must match `/^@[a-zA-Z0-9][a-zA-Z0-9-]{0,38}\/[a-z0-9][a-z0-9-]{0,213}$/` (e.g., `@JoeCardoso13/stripe`). The registry normalizes the owner to lowercase.
 2. **Version** — valid semver string (e.g., `0.1.0`)
 3. **server.type** — must be one of: `python`, `node`, `binary`
 4. **server.mcp_config** — required object with:


### PR DESCRIPTION
## Summary
- Updated the manifest name regex in `CONVENTIONS.md` and `phase-4-validate-bundle.md` to accept mixed-case owner segments (e.g., `@JoeCardoso13/stripe`)
- Added documentation that the registry normalizes the owner to lowercase

## Test plan
- [ ] Run `./scripts/validate.sh` — both skills pass
- [ ] Verify regex in both files matches: `/^@[a-zA-Z0-9][a-zA-Z0-9-]{0,38}\/[a-z0-9][a-z0-9-]{0,213}$/`

Closes https://github.com/NimbleBrainInc/contributor-toolkit/issues/37