### PR TITLE
fix: update build-mcpb tree in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,15 @@ build-mcpb/                  # Full MCP server build pipeline
 └── references/
     ├── CONVENTIONS.md
     ├── PATTERNS.md
-    └── SKILL_FORMAT.md
+    ├── SKILL_FORMAT.md
+    └── workflow/
+        ├── phase-0-bootstrap.md
+        ├── phase-1-api-analysis.md
+        ├── phase-2-scaffold.md
+        ├── phase-3-implement-and-verify.md
+        ├── phase-4-validate-bundle.md
+        ├── phase-5-embed-skill.md
+        └── phase-6-release.md
 ```
 
 ## Versioning


### PR DESCRIPTION
Add missing `references/workflow/` directory and phase files to the build-mcpb tree.

Closes https://github.com/NimbleBrainInc/contributor-toolkit/issues/41