### PR TITLE
refactor(build-mcpb): split reference files by language (PY/TS)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,9 +19,12 @@ build-mcpb/                  # Full MCP server build pipeline
 ├── CHANGELOG.md
 ├── version.txt
 └── references/
-    ├── CONVENTIONS.md
-    ├── PATTERNS.md
-    ├── SKILL_FORMAT.md
+    ├── CONVENTIONS-PY.md
+    ├── CONVENTIONS-TS.md
+    ├── PATTERNS-PY.md
+    ├── PATTERNS-TS.md
+    ├── SKILL_FORMAT-PY.md
+    ├── SKILL_FORMAT-TS.md
     └── workflow/
         ├── phase-0-bootstrap.md
         ├── phase-1-api-analysis.md

--- a/build-mcpb/SKILL.md
+++ b/build-mcpb/SKILL.md
@@ -65,6 +65,8 @@ Work through each phase in order. Read the linked workflow file for detailed ins
 
 ## References
 
-- `references/CONVENTIONS.md` — Naming, manifest format, versioning, build system, entry points
-- `references/PATTERNS.md` — Complete code patterns, directory structures, CI workflows
-- `references/SKILL_FORMAT.md` — Embedded skill resource format and wiring patterns
+Load the `{lang}`-appropriate file based on the language established in Phase 0c.
+
+- `references/CONVENTIONS-PY.md` / `CONVENTIONS-TS.md` — Naming, manifest, concept mapping, build system, entry points, template substitutions
+- `references/PATTERNS-PY.md` / `PATTERNS-TS.md` — Implementation order, code patterns, directory structure, test patterns, CI workflows
+- `references/SKILL_FORMAT-PY.md` / `SKILL_FORMAT-TS.md` — Embedded skill resource format, file location, wiring pattern

--- a/build-mcpb/references/CONVENTIONS-PY.md
+++ b/build-mcpb/references/CONVENTIONS-PY.md
@@ -1,0 +1,317 @@
+# MCP Server Conventions (Python)
+
+## Critical
+
+Package names MUST be scoped: `@<github_owner>/<name>`
+
+Name must match the registry regex: `/^@[a-zA-Z0-9][a-zA-Z0-9-]{0,38}\/[a-z0-9][a-z0-9-]{0,213}$/`
+
+The owner segment (before `/`) accepts mixed case — the registry normalizes it to lowercase. The package name (after `/`) must be lowercase.
+
+Registry rejects other formats (e.g., `ai.nimbletools/name`, underscores in name).
+
+## Naming
+
+| Aspect | Value |
+|--------|-------|
+| Package scope | `@<github_owner>/<name>` |
+| Module / package | `mcp_<name>` (underscores) |
+| Source directory | `src/mcp_<name>/` |
+| Environment variable | `<NAME>_API_KEY` |
+
+## Concept Mapping
+
+| Concept | Python |
+|---------|--------|
+| Response models | Pydantic `BaseModel` |
+| Tool input validation | Python type hints + FastMCP |
+| HTTP client | `aiohttp.ClientSession` |
+| Tool registration | `@mcp.tool()` decorator |
+| Response formatting | Return Pydantic model directly |
+| Error handling | `try/except APIError` |
+
+## Manifest (MCPB v0.4)
+
+### Required vs Optional Fields
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `name` | **Yes** | Must match `/^@[a-zA-Z0-9][a-zA-Z0-9-]{0,38}\/[a-z0-9][a-z0-9-]{0,213}$/` |
+| `version` | **Yes** | Valid semver (e.g., `0.1.0`) |
+| `description` | **Yes** | Short description |
+| `server.type` | **Yes** | `python`, `node`, or `binary` |
+| `server.mcp_config` | **Yes** | Must have `command` (string) and `args` (string array) |
+| `server.entry_point` | **Yes** | Module path (Python) or `build/index.js` (TypeScript) |
+| `manifest_version` | Recommended | `"0.4"` |
+| `author` | Recommended | `{ "name": "..." }` |
+| `user_config` | If server needs config | Each entry needs `type`; use `sensitive: true` for secrets |
+| `tools` | Recommended | Array of `{ "name": "...", "description": "..." }` |
+| `display_name` | Optional | Human-readable name |
+| `long_description` | Optional | Extended description |
+| `license` | Optional | SPDX identifier |
+| `keywords` | Optional | Array of strings |
+| `repository` | Optional | `{ "type": "git", "url": "..." }` |
+| `compatibility` | Optional | Platforms, runtimes |
+| `_meta` | Recommended | MTF permissions block |
+
+### Variable Resolution
+
+- `${user_config.<field>}` — resolves to the user's configured value for that field (used in `server.mcp_config.env`)
+
+Never use file paths (`${__dirname}/...`) for Python — breaks after bundling.
+
+### mpak.json
+
+Required for package claiming on the mpak registry. Must exist in the repo root:
+
+```json
+{
+  "name": "@<github_owner>/<name>",
+  "maintainers": ["<github-username>"]
+}
+```
+
+The `name` field must exactly match the `name` in `manifest.json`.
+
+### manifest.json Example
+
+```json
+{
+  "manifest_version": "0.4",
+  "name": "@<github_owner>/<name>",
+  "version": "0.1.0",
+  "description": "...",
+  "author": { "name": "NimbleBrain Inc" },
+  "user_config": {
+    "api_key": {
+      "type": "string",
+      "title": "API Key",
+      "description": "Your API key from...",
+      "sensitive": true,
+      "required": true
+    }
+  },
+  "server": {
+    "type": "python",
+    "entry_point": "mcp_<name>.server",
+    "mcp_config": {
+      "command": "python",
+      "args": ["-m", "mcp_<name>.server"],
+      "env": {
+        "<NAME>_API_KEY": "${user_config.api_key}"
+      }
+    }
+  },
+  "tools": [
+    { "name": "tool_name", "description": "What it does" }
+  ],
+  "_meta": {
+    "org.mpaktrust": {
+      "mtf_version": "0.1",
+      "permissions": {
+        "network": "outbound",
+        "filesystem": "none",
+        "subprocess": "none",
+        "environment": "read",
+        "native": "none"
+      }
+    }
+  }
+}
+```
+
+`server.mcp_config` is **required** — the registry uses it to generate the MCP client configuration. Both `command` and `args` must be present.
+
+## user_config (API Keys)
+
+Required format for `mpak config set` compatibility:
+
+```json
+{
+  "user_config": {
+    "api_key": {
+      "type": "string",
+      "title": "Human Readable Title",
+      "description": "Where to get this key",
+      "sensitive": true,
+      "required": true
+    }
+  }
+}
+```
+
+- Field names: lowercase with underscores (`api_key`, `database_uri`)
+- Use `sensitive: true` for secrets (not `secret`)
+- Reference via `${user_config.<field_name>}` in env mapping
+
+## server.json
+
+All servers require a `server.json` for registry metadata. This is what mpak uses to ingest and announce bundles.
+
+```json
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.<github_owner>/<name>",
+  "title": "<Display Name>",
+  "description": "...",
+  "version": "0.1.0",
+  "websiteUrl": "https://github.com/<github_owner>",
+  "repository": {
+    "url": "https://github.com/<github_owner>/mcp-<name>",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": [
+        "mcpb",
+        "pypi"
+      ],
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "mcp-<name>",
+      "version": "0.1.0",
+      "transport": { "type": "stdio" },
+      "environmentVariables": [
+        {
+          "name": "<NAME>_API_KEY",
+          "description": "...",
+          "isRequired": true,
+          "isSecret": true
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "tool": "mcpb",
+      "version": "0.4"
+    },
+    "org.mpaktrust": {
+      "mtf_version": "0.1",
+      "permissions": {
+        "network": ["<api-hostname>"],
+        "filesystem": "none",
+        "subprocess": "none"
+      }
+    }
+  }
+}
+```
+
+## Entry Points
+
+Python uses dual transport — both are required:
+
+```python
+# ASGI entrypoint (container deployment)
+app = mcp.http_app()
+
+# Stdio entrypoint (mpak / Claude Desktop)
+if __name__ == "__main__":
+    mcp.run()
+```
+
+| Context | Command | Entrypoint |
+|---------|---------|------------|
+| Containers | `uvicorn module.server:app` | `app = mcp.http_app()` |
+| mpak / Claude Desktop | `python -m module.server` | `__main__` block |
+
+The `app` object must exist at module level.
+
+## Build System
+
+`pyproject.toml` with hatchling:
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/mcp_<name>"]
+```
+
+Without this, `uv sync` won't install the package and module imports silently fail.
+
+## Version Management
+
+Three files must stay in sync:
+
+| File | Field |
+|------|-------|
+| `manifest.json` | `version` |
+| `pyproject.toml` | `version` |
+| `src/mcp_<name>/__init__.py` | `__version__` |
+
+Bump all at once: `make bump VERSION=0.2.0`
+
+## Versioning Policy
+
+All servers stay at v0.x.y until the MCP ecosystem stabilizes.
+
+- **x** (minor): Notable changes, including breaking changes to tool definitions
+- **y** (patch): Bug fixes and minor improvements
+
+## Release Process
+
+```bash
+make bump VERSION=0.2.0
+git add -A && git commit -m "Bump version to 0.2.0"
+git tag v0.2.0 && git push origin main v0.2.0
+gh release create v0.2.0 --title "v0.2.0" --notes "- changelog"
+```
+
+## Tooling
+
+| Aspect | Tool |
+|--------|------|
+| Package manager | uv |
+| Linting | ruff |
+| Formatting | ruff |
+| Type checking | ty |
+| Testing | pytest + pytest-asyncio |
+
+## Build Workflow (CI)
+
+Uses mcpb-pack v2 with release trigger. Build matrix:
+
+```yaml
+strategy:
+  matrix:
+    include:
+      - os: linux
+        arch: amd64
+        runner: ubuntu-latest
+      - os: linux
+        arch: arm64
+        runner: ubuntu-24.04-arm
+      - os: darwin
+        arch: arm64
+        runner: macos-latest
+```
+
+CI pipeline: `uv sync --dev` → `ruff format --check` → `ruff check` → `ty check` → `pytest`
+
+## Template Substitutions
+
+Immediately after cloning, `cd` into `mcp-<name>` and replace all template placeholders:
+
+1. Rename the package directory:
+   ```bash
+   mv src/mcp_example src/mcp_<name>
+   ```
+2. Replace across all files (`*.py`, `*.toml`, `*.json`, `*.md`, `Makefile`, `.env.example`):
+   - `mcp_example` → `mcp_<name>` (package name in imports, paths, logger)
+   - `mcp-example` → `mcp-<name>` (project/bundle name)
+   - `@nimblebraininc/example` → `@<github_owner>/<name>` (registry identifier)
+   - `ExampleClient` → `<Name>Client` (class name)
+   - `ExampleAPIError` → `<Name>APIError` (class name)
+   - `EXAMPLE_API_KEY` → `<NAME>_API_KEY` (env var)
+   - `https://api.example.com/v1` → leave as TODO for Phase 3 to fill with actual API URL
+   - `https://example.com/settings/api` → leave as TODO for Phase 3
+   - `mcp-server-example` → `mcp-server-<name>` (User-Agent)
+   - `FastMCP("Example")` → `FastMCP("<display>")` (server display name)
+   - `"example"` in `pyproject.toml` keywords → `"<name>"`
+   - Update `pyproject.toml` URLs to use `mcp-<name>` repo name
+   - Update README title and description to reference `<display>` instead of "Example"
+
+After substitutions, grep for any remaining `example`/`Example`/`EXAMPLE`. Fix any hits. Then confirm to the user: "Template customized — all placeholder names replaced with `<name>`."

--- a/build-mcpb/references/CONVENTIONS-TS.md
+++ b/build-mcpb/references/CONVENTIONS-TS.md
@@ -1,4 +1,4 @@
-# MCP Server Conventions
+# MCP Server Conventions (TypeScript)
 
 ## Critical
 
@@ -12,12 +12,23 @@ Registry rejects other formats (e.g., `ai.nimbletools/name`, underscores in name
 
 ## Naming
 
-| Aspect | Python | TypeScript |
-|--------|--------|------------|
-| Package scope | `@<github_owner>/<name>` | `@<github_owner>/<name>` |
-| Module / package | `mcp_<name>` (underscores) | `mcp-<name>` (hyphens) |
-| Source directory | `src/mcp_<name>/` | `src/` |
-| Environment variable | `<NAME>_API_KEY` | `<NAME>_API_KEY` |
+| Aspect | Value |
+|--------|-------|
+| Package scope | `@<github_owner>/<name>` |
+| Module / package | `mcp-<name>` (hyphens) |
+| Source directory | `src/` |
+| Environment variable | `<NAME>_API_KEY` |
+
+## Concept Mapping
+
+| Concept | TypeScript |
+|---------|------------|
+| Response models | Zod `z.object()` in `types.ts` |
+| Tool input validation | Zod schemas in `schemas.ts` |
+| HTTP client | `fetch()` built-in |
+| Tool registration | `server.registerTool()` call |
+| Response formatting | `formatters.ts` → JSON.stringify |
+| Error handling | `try/catch` → `errorResponse()` |
 
 ## Manifest (MCPB v0.4)
 
@@ -46,7 +57,7 @@ Registry rejects other formats (e.g., `ai.nimbletools/name`, underscores in name
 ### Variable Resolution
 
 - `${user_config.<field>}` — resolves to the user's configured value for that field (used in `server.mcp_config.env`)
-- `${__dirname}` — resolves to the bundle's install directory at runtime (TypeScript only; never use for Python)
+- `${__dirname}` — resolves to the bundle's install directory at runtime (use this for the entry point path)
 
 ### mpak.json
 
@@ -61,58 +72,7 @@ Required for package claiming on the mpak registry. Must exist in the repo root:
 
 The `name` field must exactly match the `name` in `manifest.json`.
 
-### Python
-
-```json
-{
-  "manifest_version": "0.4",
-  "name": "@<github_owner>/<name>",
-  "version": "0.1.0",
-  "description": "...",
-  "author": { "name": "NimbleBrain Inc" },
-  "user_config": {
-    "api_key": {
-      "type": "string",
-      "title": "API Key",
-      "description": "Your API key from...",
-      "sensitive": true,
-      "required": true
-    }
-  },
-  "server": {
-    "type": "python",
-    "entry_point": "mcp_<name>.server",
-    "mcp_config": {
-      "command": "python",
-      "args": ["-m", "mcp_<name>.server"],
-      "env": {
-        "<NAME>_API_KEY": "${user_config.api_key}"
-      }
-    }
-  },
-  "tools": [
-    { "name": "tool_name", "description": "What it does" }
-  ],
-  "_meta": {
-    "org.mpaktrust": {
-      "mtf_version": "0.1",
-      "permissions": {
-        "network": "outbound",
-        "filesystem": "none",
-        "subprocess": "none",
-        "environment": "read",
-        "native": "none"
-      }
-    }
-  }
-}
-```
-
-Never use file paths (`${__dirname}/...`) for Python — breaks after bundling.
-
-`server.mcp_config` is **required** — the registry uses it to generate the MCP client configuration. Both `command` and `args` must be present.
-
-### TypeScript
+### manifest.json Example
 
 ```json
 {
@@ -171,7 +131,9 @@ Never use file paths (`${__dirname}/...`) for Python — breaks after bundling.
 }
 ```
 
-TypeScript uses `${__dirname}/build/index.js` — this resolves correctly after bundling.
+`${__dirname}/build/index.js` resolves correctly after bundling.
+
+`server.mcp_config` is **required** — the registry uses it to generate the MCP client configuration. Both `command` and `args` must be present.
 
 ## user_config (API Keys)
 
@@ -197,7 +159,7 @@ Required format for `mpak config set` compatibility:
 
 ## server.json
 
-All servers (Python and TypeScript) require a `server.json` for registry metadata. This is what mpak uses to ingest and announce bundles.
+All servers require a `server.json` for registry metadata. This is what mpak uses to ingest and announce bundles.
 
 ```json
 {
@@ -215,10 +177,10 @@ All servers (Python and TypeScript) require a `server.json` for registry metadat
     {
       "registryType": [
         "mcpb",
-        "<see table below>"
+        "npm"
       ],
-      "registryBaseUrl": "<see table below>",
-      "identifier": "<see table below>",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@<github_owner>/<name>",
       "version": "0.1.0",
       "transport": { "type": "stdio" },
       "environmentVariables": [
@@ -248,35 +210,11 @@ All servers (Python and TypeScript) require a `server.json` for registry metadat
 }
 ```
 
-**Package fields by language:**
-
-| Field | Python | TypeScript |
-|-------|--------|------------|
-| `registryType[1]` | `pypi` | `npm` |
-| `registryBaseUrl` | `https://pypi.org` | `https://registry.npmjs.org` |
-| `identifier` | `mcp-<name>` | `@<github_owner>/<name>` |
+After editing `manifest.json`, always run `make sync` to propagate the version to `package.json`, `server.json`, and `src/constants.ts`.
 
 ## Entry Points
 
-### Python — dual transport
-
-```python
-# ASGI entrypoint (container deployment)
-app = mcp.http_app()
-
-# Stdio entrypoint (mpak / Claude Desktop)
-if __name__ == "__main__":
-    mcp.run()
-```
-
-| Context | Command | Entrypoint |
-|---------|---------|------------|
-| Containers | `uvicorn module.server:app` | `app = mcp.http_app()` |
-| mpak / Claude Desktop | `python -m module.server` | `__main__` block |
-
-Both entrypoints are required. The `app` object must exist at module level.
-
-### TypeScript — stdio only
+TypeScript uses stdio only:
 
 ```typescript
 const transport = new StdioServerTransport();
@@ -289,23 +227,6 @@ await server.connect(transport);
 | Local dev | `npm run dev` (uses tsx) |
 
 ## Build System
-
-### Python
-
-`pyproject.toml` with hatchling:
-
-```toml
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.build.targets.wheel]
-packages = ["src/mcp_<name>"]
-```
-
-Without this, `uv sync` won't install the package and module imports silently fail.
-
-### TypeScript
 
 `tsconfig.json` with `outDir: "build"`. Key npm scripts:
 
@@ -329,17 +250,7 @@ Entry point is `build/` not `dist/`.
 
 ## Version Management
 
-### Python — 3 files must stay in sync
-
-| File | Field |
-|------|-------|
-| `manifest.json` | `version` |
-| `pyproject.toml` | `version` |
-| `src/<package>/__init__.py` | `__version__` |
-
-Bump all at once: `make bump VERSION=0.2.0`
-
-### TypeScript — manifest.json is single source of truth
+`manifest.json` is the single source of truth:
 
 | File | Synced by |
 |------|-----------|
@@ -370,26 +281,18 @@ gh release create v0.2.0 --title "v0.2.0" --notes "- changelog"
 
 ## Tooling
 
-| Aspect | Python | TypeScript |
-|--------|--------|------------|
-| Package manager | uv | npm |
-| Linting | ruff | Biome |
-| Formatting | ruff | Biome |
-| Type checking | ty | tsc --noEmit |
-| Testing | pytest + pytest-asyncio | Vitest |
-| Dev runner | — | tsx |
-
-### Dependency versions (TypeScript)
-
-Use exact versions (no `^` or `~`) in `package.json`. Range specifiers are L2 MTF security findings.
-
-### .js imports (TypeScript)
-
-Node ESM requires the `.js` extension in imports: `import ... from "./foo.js"`
+| Aspect | Tool |
+|--------|------|
+| Package manager | npm |
+| Linting | Biome |
+| Formatting | Biome |
+| Type checking | tsc --noEmit |
+| Testing | Vitest |
+| Dev runner | tsx |
 
 ## Build Workflow (CI)
 
-Uses mcpb-pack v2 with release trigger. Both languages use the same matrix:
+Uses mcpb-pack v2 with release trigger. Build matrix:
 
 ```yaml
 strategy:
@@ -406,5 +309,27 @@ strategy:
         runner: macos-latest
 ```
 
-Python CI: `uv sync --dev` → ruff format --check → ruff check → ty check → pytest
-TypeScript CI: `npm ci` → format:check → lint → typecheck → test → build → bundle test
+CI pipeline: `npm ci` → `format:check` → `lint` → `typecheck` → `test` → `build` → bundle test
+
+## Critical Notes
+
+- Use **exact dependency versions** (no `^` or `~`) in `package.json` — range specifiers are L2 MTF security findings
+- Use `.js` extensions in all imports (Node ESM requirement): `import ... from "./foo.js"`
+- Never edit `src/constants.ts` manually — use `make sync`
+- Never edit `.github/workflows/` — shared infrastructure
+- The embedded SKILL.md lives in `src/` and is copied to `build/` during compilation
+
+## Template Substitutions
+
+Immediately after cloning, `cd` into `mcp-<name>` and replace all template placeholders across `*.ts`, `*.json`, `*.md`, `Makefile`, `CLAUDE.md`:
+
+- `YOUR_SERVER_NAME` → `<name>`
+- `YOUR_DISPLAY_NAME` → `<display>`
+- `YOUR_REPO_NAME` → `mcp-<name>`
+- `YOUR_API_KEY_ENV_VAR` → `<NAME>_API_KEY`
+- `YOUR_API_HOST` → leave as TODO for Phase 3
+- `YOUR_API_BASE_URL` → leave as TODO for Phase 3
+- `YOUR_GITHUB_USERNAME` → `<github_owner>` (already detected in Phase 0b)
+- `YOUR_SERVICE` → `<display>`
+
+After substitutions, grep for any remaining `YOUR_`. Fix any hits. Then confirm to the user: "Template customized — all placeholder names replaced with `<name>`."

--- a/build-mcpb/references/PATTERNS-PY.md
+++ b/build-mcpb/references/PATTERNS-PY.md
@@ -1,8 +1,6 @@
-# MCP Server Code Patterns
+# MCP Server Code Patterns (Python)
 
-## Python Server Patterns
-
-### Directory Structure
+## Directory Structure
 
 ```
 <server-name>/
@@ -39,7 +37,14 @@
 └── README.md
 ```
 
-### .gitignore (Python)
+## Implementation Order
+
+1. **`api_models.py`** — Pydantic models for API responses. Use `Field(alias=...)` for camelCase mapping.
+2. **`api_client.py`** — Async aiohttp client. Set BASE_URL, add one method per endpoint.
+3. **`server.py`** — FastMCP server with `@mcp.tool()` decorators. Global client with lazy init. Dual transport (http_app + stdio).
+4. **`manifest.json`** + **`server.json`** — Fill all placeholder fields. See `CONVENTIONS-PY.md` for the full schema.
+
+## .gitignore
 
 ```
 # Python
@@ -109,7 +114,7 @@ deps/
 security-report.json
 ```
 
-### pyproject.toml
+## pyproject.toml
 
 ```toml
 [project]
@@ -148,7 +153,7 @@ dev = [
 ]
 ```
 
-### server.py
+## server.py
 
 ```python
 """<Service> MCP Server - FastMCP Implementation."""
@@ -234,7 +239,7 @@ if __name__ == "__main__":
     mcp.run()
 ```
 
-### api_client.py
+## api_client.py
 
 ```python
 import os
@@ -320,7 +325,7 @@ class Client:
         return response.data.items
 ```
 
-### api_models.py
+## api_models.py
 
 ```python
 from enum import Enum
@@ -352,7 +357,7 @@ class SomeListResponse(BaseModel):
     data: Data
 ```
 
-### .mcpbignore (Python)
+## .mcpbignore
 
 ```
 .venv/
@@ -379,7 +384,7 @@ CLAUDE.md
 *.png
 ```
 
-### CI Workflows (Python)
+## CI Workflows
 
 **ci.yml:**
 ```yaml
@@ -487,7 +492,7 @@ jobs:
           "
 ```
 
-### Makefile `bundle` Target (Python)
+## `bundle` Target (Makefile)
 
 ```makefile
 bundle: ## Build MCPB bundle locally
@@ -499,7 +504,7 @@ bundle: ## Build MCPB bundle locally
 
 This vendors dependencies into `deps/` (same as the GitHub Action does), then packs. Contributors can validate bundles locally before releasing.
 
-### Test Patterns (Python)
+## Test Patterns
 
 Three test layers, each with its own directory and concerns:
 
@@ -637,7 +642,7 @@ class TestSkillLLMInvocation:
         assert tool_calls[0].name == "expected_tool_name"
 ```
 
-### Build & Test Commands (Python)
+## Build & Test Commands
 
 ```bash
 uv sync --dev                        # Install dependencies
@@ -659,546 +664,7 @@ make bundle                          # Vendor deps + mcpb pack (local bundle)
 
 ---
 
-## TypeScript Server Patterns
-
-### Directory Structure
-
-```
-<server-name>/
-├── .github/workflows/
-│   ├── build-bundle.yml
-│   ├── ci.yml
-│   └── scan.yml
-├── src/
-│   ├── index.ts              # Server entry point + tool registration
-│   ├── config.ts             # Loads API key from env
-│   ├── constants.ts          # SERVER_NAME + VERSION (managed by make sync)
-│   ├── types.ts              # Zod schemas for API responses
-│   ├── schemas.ts            # Zod schemas for tool inputs
-│   ├── formatters.ts         # Strip noisy API fields before returning
-│   ├── SKILL.md              # Embedded skill resource
-│   ├── handlers/             # One file per tool
-│   │   └── <tool>.ts
-│   └── utils/
-│       ├── apiClient.ts      # HTTP client wrapping third-party API
-│       └── errorResponse.ts  # Converts errors → MCP CallToolResult
-├── tests/
-│   ├── server.test.ts
-│   ├── client.test.ts
-│   └── fixtures.ts
-├── .gitignore
-├── .mcpbignore
-├── CLAUDE.md
-├── LICENSE
-├── Makefile
-├── README.md
-├── biome.json
-├── manifest.json             # MCPB manifest (v0.4) — version source of truth
-├── mpak.json
-├── package.json
-├── package-lock.json
-├── server.json               # Registry metadata
-├── tsconfig.json
-└── vitest.config.ts
-```
-
-### .gitignore (TypeScript)
-
-```
-# Node
-node_modules/
-build/
-dist/
-*.tgz
-
-# Environment
-.env
-.env.*
-!.env.example
-
-# IDEs
-.vscode/
-.idea/
-*.code-workspace
-
-# OS
-.DS_Store
-Thumbs.db
-
-# Claude
-.claude/
-
-# Testing
-coverage/
-.nyc_output/
-
-# MCPB bundles
-bundle/
-deps/
-*.mcpb
-
-# Scanner reports
-security-report.json
-.scan-results.json
-
-# Secrets
-*.key
-*.pem
-credentials.json
-.secrets/
-
-# Temp files
-tmp/
-temp/
-*.tmp
-*.swp
-```
-
-### Implementation Order
-
-1. `src/types.ts` — Zod schemas for API response shapes
-2. `src/utils/apiClient.ts` — rename class, set BASE_URL, add methods; also update import in `errorResponse.ts`
-3. `src/schemas.ts` — Zod input schema for each tool
-4. `src/formatters.ts` — one formatter per resource type (pure functions)
-5. `src/handlers/<tool>.ts` — one file per tool
-6. `src/index.ts` — `server.registerTool()` for each tool
-7. `src/config.ts` — rename env var
-8. `src/constants.ts` — set SERVER_NAME only (version managed by `make sync`)
-9. `manifest.json` + `server.json` — fill all TODO fields; run `make sync`
-10. `tests/` — fixtures + tests
-11. `src/SKILL.md` — embedded skill resource (tool selection, workflows)
-
-### index.ts (Entry Point)
-
-```typescript
-#!/usr/bin/env node
-
-import { readFileSync } from "fs";
-import { join } from "path";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { loadConfig } from "./config.js";
-import { VERSION, SERVER_NAME } from "./constants.js";
-import { ApiClient } from "./utils/apiClient.js";
-
-import { MyInputSchema } from "./schemas.js";
-import { myHandler } from "./handlers/myHandler.js";
-
-const SKILL_CONTENT = readFileSync(join(__dirname, "SKILL.md"), "utf-8");
-
-const config = loadConfig();
-const client = new ApiClient(config.apiKey);
-
-const server = new McpServer({
-  name: SERVER_NAME,
-  version: VERSION,
-  instructions: "Read the skill resource at skill://<name>/usage before using tools.",
-});
-
-// Skill resource
-server.resource("skill-usage", "skill://<name>/usage", async (uri) => ({
-  contents: [{ uri: uri.href, text: SKILL_CONTENT, mimeType: "text/markdown" }],
-}));
-
-// Tool registration
-server.registerTool(
-  "tool_name",
-  {
-    description: "What this tool does",
-    inputSchema: MyInputSchema.shape,
-    annotations: { readOnlyHint: true },
-  },
-  (args) => myHandler(client, args),
-);
-
-async function main() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error(`${SERVER_NAME} MCP server v${VERSION} running on stdio`);
-}
-
-main().catch((e) => {
-  console.error("Fatal error:", e);
-  process.exit(1);
-});
-```
-
-### config.ts
-
-```typescript
-export function loadConfig() {
-  const apiKey = process.env.<NAME>_API_KEY;
-  if (!apiKey) {
-    console.error("<NAME>_API_KEY environment variable is required");
-    process.exit(1);
-  }
-  return { apiKey };
-}
-```
-
-### types.ts (API Response Schemas)
-
-```typescript
-import { z } from "zod";
-
-export const MyResourceSchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  created_at: z.string(),
-});
-export type MyResource = z.infer<typeof MyResourceSchema>;
-
-// Paginated response helper
-export const paginatedSchema = <T extends z.ZodTypeAny>(item: T) =>
-  z.object({
-    collection: z.array(item),
-    pagination: z.object({
-      count: z.number(),
-      next_page: z.string().nullable(),
-      next_page_token: z.string().nullable(),
-    }),
-  });
-```
-
-### schemas.ts (Tool Input Schemas)
-
-```typescript
-import { z } from "zod";
-
-export const GetItemSchema = z.object({
-  item_id: z.string().describe("The unique ID of the item"),
-});
-
-export const ListItemsSchema = z.object({
-  count: z.number().optional().describe("Maximum number of items to return"),
-  page_token: z.string().optional().describe("Pagination token"),
-});
-```
-
-### utils/apiClient.ts
-
-```typescript
-export class ApiError extends Error {
-  constructor(
-    public status: number,
-    public statusText: string,
-    message: string,
-  ) {
-    super(message);
-    this.name = "ApiError";
-  }
-}
-
-const BASE_URL = "https://api.example.com";
-
-export class ApiClient {
-  private apiKey: string;
-
-  constructor(apiKey: string) {
-    this.apiKey = apiKey;
-  }
-
-  protected async request(path: string, options?: RequestInit): Promise<unknown> {
-    const url = path.startsWith("http") ? path : `${BASE_URL}${path}`;
-    const res = await fetch(url, {
-      ...options,
-      headers: {
-        Authorization: `Bearer ${this.apiKey}`,
-        "Content-Type": "application/json",
-        ...options?.headers,
-      },
-    });
-
-    if (!res.ok) {
-      const body = await res.text();
-      throw new ApiError(res.status, res.statusText, `API error ${res.status}: ${body}`);
-    }
-
-    return res.json();
-  }
-
-  async getItem(id: string): Promise<MyResource> {
-    const data = await this.request(`/items/${id}`);
-    return MyResourceSchema.parse((data as { resource: unknown }).resource);
-  }
-}
-```
-
-### utils/errorResponse.ts
-
-```typescript
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { ApiError } from "./apiClient.js";
-
-export function errorResponse(e: unknown): CallToolResult {
-  const msg = e instanceof ApiError ? e.message : String(e);
-  return { content: [{ type: "text", text: `Error: ${msg}` }], isError: true };
-}
-```
-
-### handlers/<tool>.ts
-
-```typescript
-import type { z } from "zod";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { ApiClient } from "../utils/apiClient.js";
-import { errorResponse } from "../utils/errorResponse.js";
-import { formatMyResource } from "../formatters.js";
-import type { MyInputSchema } from "../schemas.js";
-
-export async function myHandler(
-  client: ApiClient,
-  args: z.infer<typeof MyInputSchema>,
-): Promise<CallToolResult> {
-  try {
-    const result = await client.myMethod(args.some_field);
-    return { content: [{ type: "text", text: JSON.stringify(formatMyResource(result), null, 2) }] };
-  } catch (e) {
-    return errorResponse(e);
-  }
-}
-```
-
-### formatters.ts
-
-```typescript
-import type { MyResource } from "./types.js";
-
-export function formatMyResource(r: MyResource) {
-  return {
-    id: r.id,
-    name: r.name,
-    created_at: r.created_at,
-    // omit large or irrelevant fields
-  };
-}
-```
-
-### Test Pattern
-
-Tests use `InMemoryTransport` with a real `McpServer` + `Client` pair:
-
-```typescript
-import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-
-// Mock client — one vi.fn() per client method
-const mocks = {
-  myMethod: vi.fn(),
-};
-const mockClient = mocks as unknown as ApiClient;
-
-function createTestServer(): McpServer {
-  const server = new McpServer({ name: "test-server", version: "0.0.0" });
-  server.registerTool(
-    "tool_name",
-    { description: "...", inputSchema: MyInputSchema.shape },
-    (args): Promise<CallToolResult> => myHandler(mockClient, args),
-  );
-  return server;
-}
-
-describe("MCP server", () => {
-  let client: Client;
-  let server: McpServer;
-
-  beforeAll(async () => {
-    server = createTestServer();
-    client = new Client({ name: "test-client", version: "0.0.0" });
-    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-    await Promise.all([
-      client.connect(clientTransport),
-      server.connect(serverTransport),
-    ]);
-  });
-
-  afterAll(async () => {
-    await client.close();
-    await server.close();
-  });
-
-  function getText(result: Awaited<ReturnType<typeof client.callTool>>) {
-    return (result.content as Array<{ type: string; text: string }>)[0].text;
-  }
-
-  it("returns formatted result", async () => {
-    mocks.myMethod.mockResolvedValueOnce(mockMyResource);
-    const result = await client.callTool({ name: "tool_name", arguments: { id: "123" } });
-    const parsed = JSON.parse(getText(result));
-    expect(parsed.id).toBe("123");
-  });
-
-  it("returns error for API failure", async () => {
-    mocks.myMethod.mockRejectedValueOnce(new Error("fail"));
-    const result = await client.callTool({ name: "tool_name", arguments: { id: "bad" } });
-    expect(result.isError).toBe(true);
-  });
-});
-```
-
-### .mcpbignore (TypeScript)
-
-```
-.git/
-.github/
-.vscode/
-.idea/
-.claude/
-tests/
-e2e/
-scripts/
-src/
-*.mcpb
-.env
-.env.*
-!.env.example
-Makefile
-tsconfig.json
-vitest.config.ts
-biome.json
-pyproject.toml
-CLAUDE.md
-README.md
-*.png
-*.security-report.json
-!package-lock.json
-!build/SKILL.md
-```
-
-> **Note:** The `*.md` and `src/` exclusions would prevent the embedded SKILL.md from being bundled. The `!build/SKILL.md` negation overrides both. The Makefile `build` target must include `cp src/SKILL.md build/SKILL.md` so the file is available at the expected path.
-
-### CI Workflows (TypeScript)
-
-**ci.yml:**
-```yaml
-name: CI
-on:
-  pull_request:
-    branches: [main]
-
-jobs:
-  version-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Check version consistency
-        run: |
-          VERSION=$(jq -r '.version' manifest.json)
-          PKG=$(jq -r '.version' package.json)
-          SRV=$(jq -r '.version' server.json)
-          SRV_PKG=$(jq -r '.packages[0].version' server.json)
-          CONSTANTS=$(sed -n 's/export const VERSION = "\(.*\)";/\1/p' src/constants.ts)
-          FAIL=0
-          [ "$PKG" != "$VERSION" ] && echo "MISMATCH: package.json" && FAIL=1
-          [ "$SRV" != "$VERSION" ] && echo "MISMATCH: server.json" && FAIL=1
-          [ "$SRV_PKG" != "$VERSION" ] && echo "MISMATCH: server.json packages" && FAIL=1
-          [ "$CONSTANTS" != "$VERSION" ] && echo "MISMATCH: constants.ts" && FAIL=1
-          exit $FAIL
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: "npm"
-      - run: npm ci
-      - run: npm run format:check
-      - run: npm run lint
-      - run: npm run typecheck
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: "npm"
-      - run: npm ci
-      - run: npm run build
-      - run: npm run test
-
-  bundle:
-    runs-on: ubuntu-latest
-    needs: [version-check, lint, test]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: "npm"
-      - run: npm ci && npm run build
-      - run: npm prune --omit=dev
-      - run: npx @anthropic-ai/mcpb pack && ls -la *.mcpb
-```
-
-**build-bundle.yml:**
-```yaml
-name: Build MCPB Bundle
-on:
-  release:
-    types: [published]
-
-permissions:
-  contents: write
-  id-token: write
-
-jobs:
-  build:
-    strategy:
-      matrix:
-        include:
-          - os: linux
-            arch: amd64
-            runner: ubuntu-latest
-          - os: linux
-            arch: arm64
-            runner: ubuntu-24.04-arm
-          - os: darwin
-            arch: arm64
-            runner: macos-latest
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: "npm"
-      - run: npm ci && npm run build
-      - run: npm prune --omit=dev
-      - uses: NimbleBrainInc/mcpb-pack@v2
-        with:
-          output: "{name}-{version}-${{ matrix.os }}-${{ matrix.arch }}.mcpb"
-```
-
-### Build & Test Commands (TypeScript)
-
-```bash
-npm install                          # Install dependencies
-npm run format:check                 # Check formatting (Biome)
-npm run lint                         # Lint (Biome)
-npm run typecheck                    # Type check (tsc --noEmit)
-npm run test                         # Test (Vitest)
-make check                           # All of the above
-
-npm run build                        # Compile TypeScript → build/
-make bundle                          # Build + prune + mcpb pack
-
-# Test locally
-<NAME>_API_KEY=xxx node build/index.js --stdio
-
-# Test with MCP Inspector
-<NAME>_API_KEY=xxx npx @modelcontextprotocol/inspector node build/index.js --stdio
-```
-
----
-
-## Tool Design Guidelines (Both Languages)
+## Tool Design Guidelines
 
 1. **One tool per operation**: `list_items`, `get_item`, `create_item`, etc.
 2. **Clear descriptions**: What the tool does, its arguments, its return value

--- a/build-mcpb/references/PATTERNS-TS.md
+++ b/build-mcpb/references/PATTERNS-TS.md
@@ -1,0 +1,560 @@
+# MCP Server Code Patterns (TypeScript)
+
+## Directory Structure
+
+```
+<server-name>/
+├── .github/workflows/
+│   ├── build-bundle.yml
+│   ├── ci.yml
+│   └── scan.yml
+├── src/
+│   ├── index.ts              # Server entry point + tool registration
+│   ├── config.ts             # Loads API key from env
+│   ├── constants.ts          # SERVER_NAME + VERSION (managed by make sync)
+│   ├── types.ts              # Zod schemas for API responses
+│   ├── schemas.ts            # Zod schemas for tool inputs
+│   ├── formatters.ts         # Strip noisy API fields before returning
+│   ├── SKILL.md              # Embedded skill resource
+│   ├── handlers/             # One file per tool
+│   │   └── <tool>.ts
+│   └── utils/
+│       ├── apiClient.ts      # HTTP client wrapping third-party API
+│       └── errorResponse.ts  # Converts errors → MCP CallToolResult
+├── tests/
+│   ├── server.test.ts
+│   ├── client.test.ts
+│   └── fixtures.ts
+├── .gitignore
+├── .mcpbignore
+├── CLAUDE.md
+├── LICENSE
+├── Makefile
+├── README.md
+├── biome.json
+├── manifest.json             # MCPB manifest (v0.4) — version source of truth
+├── mpak.json
+├── package.json
+├── package-lock.json
+├── server.json               # Registry metadata
+├── tsconfig.json
+└── vitest.config.ts
+```
+
+## .gitignore
+
+```
+# Node
+node_modules/
+build/
+dist/
+*.tgz
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# IDEs
+.vscode/
+.idea/
+*.code-workspace
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Claude
+.claude/
+
+# Testing
+coverage/
+.nyc_output/
+
+# MCPB bundles
+bundle/
+deps/
+*.mcpb
+
+# Scanner reports
+security-report.json
+.scan-results.json
+
+# Secrets
+*.key
+*.pem
+credentials.json
+.secrets/
+
+# Temp files
+tmp/
+temp/
+*.tmp
+*.swp
+```
+
+## Implementation Order
+
+1. `src/types.ts` — Zod schemas for API response shapes
+2. `src/utils/apiClient.ts` — rename class, set BASE_URL, add methods; also update import in `errorResponse.ts`
+3. `src/schemas.ts` — Zod input schema for each tool
+4. `src/formatters.ts` — one formatter per resource type (pure functions)
+5. `src/handlers/<tool>.ts` — one file per tool
+6. `src/index.ts` — `server.registerTool()` for each tool
+7. `src/config.ts` — rename env var
+8. `src/constants.ts` — set SERVER_NAME only (version managed by `make sync`)
+9. `manifest.json` + `server.json` — fill all TODO fields; run `make sync`
+10. `tests/` — fixtures + tests
+11. `src/SKILL.md` — embedded skill resource (tool selection, workflows)
+
+## index.ts (Entry Point)
+
+```typescript
+#!/usr/bin/env node
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { loadConfig } from "./config.js";
+import { VERSION, SERVER_NAME } from "./constants.js";
+import { ApiClient } from "./utils/apiClient.js";
+
+import { MyInputSchema } from "./schemas.js";
+import { myHandler } from "./handlers/myHandler.js";
+
+const SKILL_CONTENT = readFileSync(join(__dirname, "SKILL.md"), "utf-8");
+
+const config = loadConfig();
+const client = new ApiClient(config.apiKey);
+
+const server = new McpServer({
+  name: SERVER_NAME,
+  version: VERSION,
+  instructions: "Read the skill resource at skill://<name>/usage before using tools.",
+});
+
+// Skill resource
+server.resource("skill-usage", "skill://<name>/usage", async (uri) => ({
+  contents: [{ uri: uri.href, text: SKILL_CONTENT, mimeType: "text/markdown" }],
+}));
+
+// Tool registration
+server.registerTool(
+  "tool_name",
+  {
+    description: "What this tool does",
+    inputSchema: MyInputSchema.shape,
+    annotations: { readOnlyHint: true },
+  },
+  (args) => myHandler(client, args),
+);
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(`${SERVER_NAME} MCP server v${VERSION} running on stdio`);
+}
+
+main().catch((e) => {
+  console.error("Fatal error:", e);
+  process.exit(1);
+});
+```
+
+## config.ts
+
+```typescript
+export function loadConfig() {
+  const apiKey = process.env.<NAME>_API_KEY;
+  if (!apiKey) {
+    console.error("<NAME>_API_KEY environment variable is required");
+    process.exit(1);
+  }
+  return { apiKey };
+}
+```
+
+## types.ts (API Response Schemas)
+
+```typescript
+import { z } from "zod";
+
+export const MyResourceSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  created_at: z.string(),
+});
+export type MyResource = z.infer<typeof MyResourceSchema>;
+
+// Paginated response helper
+export const paginatedSchema = <T extends z.ZodTypeAny>(item: T) =>
+  z.object({
+    collection: z.array(item),
+    pagination: z.object({
+      count: z.number(),
+      next_page: z.string().nullable(),
+      next_page_token: z.string().nullable(),
+    }),
+  });
+```
+
+## schemas.ts (Tool Input Schemas)
+
+```typescript
+import { z } from "zod";
+
+export const GetItemSchema = z.object({
+  item_id: z.string().describe("The unique ID of the item"),
+});
+
+export const ListItemsSchema = z.object({
+  count: z.number().optional().describe("Maximum number of items to return"),
+  page_token: z.string().optional().describe("Pagination token"),
+});
+```
+
+## utils/apiClient.ts
+
+```typescript
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    public statusText: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+const BASE_URL = "https://api.example.com";
+
+export class ApiClient {
+  private apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  protected async request(path: string, options?: RequestInit): Promise<unknown> {
+    const url = path.startsWith("http") ? path : `${BASE_URL}${path}`;
+    const res = await fetch(url, {
+      ...options,
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json",
+        ...options?.headers,
+      },
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new ApiError(res.status, res.statusText, `API error ${res.status}: ${body}`);
+    }
+
+    return res.json();
+  }
+
+  async getItem(id: string): Promise<MyResource> {
+    const data = await this.request(`/items/${id}`);
+    return MyResourceSchema.parse((data as { resource: unknown }).resource);
+  }
+}
+```
+
+## utils/errorResponse.ts
+
+```typescript
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { ApiError } from "./apiClient.js";
+
+export function errorResponse(e: unknown): CallToolResult {
+  const msg = e instanceof ApiError ? e.message : String(e);
+  return { content: [{ type: "text", text: `Error: ${msg}` }], isError: true };
+}
+```
+
+## handlers/\<tool\>.ts
+
+```typescript
+import type { z } from "zod";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { ApiClient } from "../utils/apiClient.js";
+import { errorResponse } from "../utils/errorResponse.js";
+import { formatMyResource } from "../formatters.js";
+import type { MyInputSchema } from "../schemas.js";
+
+export async function myHandler(
+  client: ApiClient,
+  args: z.infer<typeof MyInputSchema>,
+): Promise<CallToolResult> {
+  try {
+    const result = await client.myMethod(args.some_field);
+    return { content: [{ type: "text", text: JSON.stringify(formatMyResource(result), null, 2) }] };
+  } catch (e) {
+    return errorResponse(e);
+  }
+}
+```
+
+## formatters.ts
+
+```typescript
+import type { MyResource } from "./types.js";
+
+export function formatMyResource(r: MyResource) {
+  return {
+    id: r.id,
+    name: r.name,
+    created_at: r.created_at,
+    // omit large or irrelevant fields
+  };
+}
+```
+
+## Test Pattern
+
+Tests use `InMemoryTransport` with a real `McpServer` + `Client` pair:
+
+```typescript
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+// Mock client — one vi.fn() per client method
+const mocks = {
+  myMethod: vi.fn(),
+};
+const mockClient = mocks as unknown as ApiClient;
+
+function createTestServer(): McpServer {
+  const server = new McpServer({ name: "test-server", version: "0.0.0" });
+  server.registerTool(
+    "tool_name",
+    { description: "...", inputSchema: MyInputSchema.shape },
+    (args): Promise<CallToolResult> => myHandler(mockClient, args),
+  );
+  return server;
+}
+
+describe("MCP server", () => {
+  let client: Client;
+  let server: McpServer;
+
+  beforeAll(async () => {
+    server = createTestServer();
+    client = new Client({ name: "test-client", version: "0.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      client.connect(clientTransport),
+      server.connect(serverTransport),
+    ]);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  function getText(result: Awaited<ReturnType<typeof client.callTool>>) {
+    return (result.content as Array<{ type: string; text: string }>)[0].text;
+  }
+
+  it("returns formatted result", async () => {
+    mocks.myMethod.mockResolvedValueOnce(mockMyResource);
+    const result = await client.callTool({ name: "tool_name", arguments: { id: "123" } });
+    const parsed = JSON.parse(getText(result));
+    expect(parsed.id).toBe("123");
+  });
+
+  it("returns error for API failure", async () => {
+    mocks.myMethod.mockRejectedValueOnce(new Error("fail"));
+    const result = await client.callTool({ name: "tool_name", arguments: { id: "bad" } });
+    expect(result.isError).toBe(true);
+  });
+});
+```
+
+## .mcpbignore
+
+```
+.git/
+.github/
+.vscode/
+.idea/
+.claude/
+tests/
+e2e/
+scripts/
+src/
+*.mcpb
+.env
+.env.*
+!.env.example
+Makefile
+tsconfig.json
+vitest.config.ts
+biome.json
+pyproject.toml
+CLAUDE.md
+README.md
+*.png
+*.security-report.json
+!package-lock.json
+!build/SKILL.md
+```
+
+> **Note:** The `*.md` and `src/` exclusions would prevent the embedded SKILL.md from being bundled. The `!build/SKILL.md` negation overrides both. The Makefile `build` target must include `cp src/SKILL.md build/SKILL.md` so the file is available at the expected path.
+
+## CI Workflows
+
+**ci.yml:**
+```yaml
+name: CI
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check version consistency
+        run: |
+          VERSION=$(jq -r '.version' manifest.json)
+          PKG=$(jq -r '.version' package.json)
+          SRV=$(jq -r '.version' server.json)
+          SRV_PKG=$(jq -r '.packages[0].version' server.json)
+          CONSTANTS=$(sed -n 's/export const VERSION = "\(.*\)";/\1/p' src/constants.ts)
+          FAIL=0
+          [ "$PKG" != "$VERSION" ] && echo "MISMATCH: package.json" && FAIL=1
+          [ "$SRV" != "$VERSION" ] && echo "MISMATCH: server.json" && FAIL=1
+          [ "$SRV_PKG" != "$VERSION" ] && echo "MISMATCH: server.json packages" && FAIL=1
+          [ "$CONSTANTS" != "$VERSION" ] && echo "MISMATCH: constants.ts" && FAIL=1
+          exit $FAIL
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run format:check
+      - run: npm run lint
+      - run: npm run typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test
+
+  bundle:
+    runs-on: ubuntu-latest
+    needs: [version-check, lint, test]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+      - run: npm ci && npm run build
+      - run: npm prune --omit=dev
+      - run: npx @anthropic-ai/mcpb pack && ls -la *.mcpb
+```
+
+**build-bundle.yml:**
+```yaml
+name: Build MCPB Bundle
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+            runner: ubuntu-latest
+          - os: linux
+            arch: arm64
+            runner: ubuntu-24.04-arm
+          - os: darwin
+            arch: arm64
+            runner: macos-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+      - run: npm ci && npm run build
+      - run: npm prune --omit=dev
+      - uses: NimbleBrainInc/mcpb-pack@v2
+        with:
+          output: "{name}-{version}-${{ matrix.os }}-${{ matrix.arch }}.mcpb"
+```
+
+## Build & Test Commands
+
+```bash
+npm install                          # Install dependencies
+npm run format:check                 # Check formatting (Biome)
+npm run lint                         # Lint (Biome)
+npm run typecheck                    # Type check (tsc --noEmit)
+npm run test                         # Test (Vitest)
+make check                           # All of the above
+
+npm run build                        # Compile TypeScript → build/
+make bundle                          # Build + prune + mcpb pack
+
+# Test locally
+<NAME>_API_KEY=xxx node build/index.js --stdio
+
+# Test with MCP Inspector
+<NAME>_API_KEY=xxx npx @modelcontextprotocol/inspector node build/index.js --stdio
+```
+
+---
+
+## Tool Design Guidelines
+
+1. **One tool per operation**: `list_items`, `get_item`, `create_item`, etc.
+2. **Clear descriptions**: What the tool does, its arguments, its return value
+3. **Sensible defaults**: Pagination limits, optional filters
+4. **Error handling**: Catch API errors, return structured error messages
+5. **Search tools**: Add convenience wrappers if API supports filtering
+
+## API Analysis Checklist
+
+When analyzing an API to build an MCP server:
+
+1. **Authentication**: Bearer token, API key, OAuth?
+2. **Base URL**: What's the API base URL?
+3. **Resources**: What entities exist?
+4. **Operations**: CRUD operations available?
+5. **Pagination**: Cursor-based, offset-based?
+6. **Filtering**: What filter parameters are supported?
+7. **Response format**: JSON structure, nested objects?
+8. **Rate limits**: Any limits to be aware of?
+9. **OpenAPI spec**: Is one available?

--- a/build-mcpb/references/SKILL_FORMAT-PY.md
+++ b/build-mcpb/references/SKILL_FORMAT-PY.md
@@ -1,0 +1,59 @@
+# Embedded Skill Resource Format (Python)
+
+## Overview
+
+An embedded skill resource is a single `SKILL.md` file that lives **inside** the MCP server package and is exposed as an MCP resource at `skill://<name>/usage`. It is NOT a standalone artifact — there is no `mpak skill validate` and no separate distribution step. The skill ships automatically with the `.mcpb` bundle.
+
+## File Location
+
+`src/mcp_<name>/SKILL.md`
+
+## Frontmatter
+
+The file begins with YAML frontmatter containing the skill's identity:
+
+```yaml
+---
+name: mcp-<name>-service
+description: Provides knowledge of how to use MCP <name> most effectively. It's loaded into the agent's context when running the MCP.
+---
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Skill identifier, following the `mcp-<name>-service` convention |
+| `description` | Yes | One-line summary of what the skill provides |
+
+## Content Structure
+
+After the frontmatter, the Markdown body should contain:
+
+1. **Tool selection table** — lists each tool with a one-line description and when to use it
+2. **Context reuse rules** — which tool outputs to feed into subsequent calls (e.g., "use the `id` from `list_items` when calling `get_item`")
+3. **Multi-step workflow patterns** — 2–3 composed workflows showing how to chain tools for real tasks
+
+## Wiring Pattern
+
+```python
+from importlib.resources import files
+
+SKILL_CONTENT = files("mcp_<name>").joinpath("SKILL.md").read_text()
+
+mcp = FastMCP(
+    "<Service>",
+    instructions="Read the skill resource at skill://<name>/usage before using tools.",
+)
+
+@mcp.resource("skill://<name>/usage")
+def get_skill() -> str:
+    """Tool selection guide and workflow patterns for this server."""
+    return SKILL_CONTENT
+```
+
+## Quality Checklist
+
+- [ ] Covers all tools exposed by the server
+- [ ] Composes 2+ tools per workflow pattern
+- [ ] Context reuse specified (which outputs feed into which inputs)
+- [ ] Resource URI matches `skill://<name>/usage`
+- [ ] Server `instructions` parameter directs the LLM to read the skill resource

--- a/build-mcpb/references/SKILL_FORMAT-TS.md
+++ b/build-mcpb/references/SKILL_FORMAT-TS.md
@@ -1,4 +1,4 @@
-# Embedded Skill Resource Format
+# Embedded Skill Resource Format (TypeScript)
 
 ## Overview
 
@@ -6,10 +6,7 @@ An embedded skill resource is a single `SKILL.md` file that lives **inside** the
 
 ## File Location
 
-| Language | Path |
-|----------|------|
-| Python | `src/mcp_<name>/SKILL.md` |
-| TypeScript | `src/SKILL.md` |
+`src/SKILL.md`
 
 ## Frontmatter
 
@@ -35,27 +32,7 @@ After the frontmatter, the Markdown body should contain:
 2. **Context reuse rules** — which tool outputs to feed into subsequent calls (e.g., "use the `id` from `list_items` when calling `get_item`")
 3. **Multi-step workflow patterns** — 2–3 composed workflows showing how to chain tools for real tasks
 
-## Wiring Patterns
-
-### Python (FastMCP)
-
-```python
-from importlib.resources import files
-
-SKILL_CONTENT = files("mcp_<name>").joinpath("SKILL.md").read_text()
-
-mcp = FastMCP(
-    "<Service>",
-    instructions="Read the skill resource at skill://<name>/usage before using tools.",
-)
-
-@mcp.resource("skill://<name>/usage")
-def get_skill() -> str:
-    """Tool selection guide and workflow patterns for this server."""
-    return SKILL_CONTENT
-```
-
-### TypeScript (@modelcontextprotocol/sdk)
+## Wiring Pattern
 
 ```typescript
 import { readFileSync } from "fs";
@@ -74,7 +51,7 @@ server.resource("skill-usage", "skill://<name>/usage", async (uri) => ({
 }));
 ```
 
-### TypeScript Bundling Note
+### Bundling Note
 
 The `.mcpbignore` excludes both `src/` and `*.md`, so the SKILL.md must be copied during build:
 

--- a/build-mcpb/references/workflow/phase-0-bootstrap.md
+++ b/build-mcpb/references/workflow/phase-0-bootstrap.md
@@ -43,7 +43,7 @@ If cold start, verify the basics before proceeding:
 3. **mpak CLI** — `mpak --version` succeeds
 4. **GitHub owner** — detect the user's login via `gh api user --jq .login` as a default, then ask: "Repo owner will be `<detected_login>` — or would you prefer a different org/account?" If the user specifies a different owner, use that as `<github_owner>`. The mpak registry allows any GitHub user or org to publish under their own scope (`@<owner>/*` must match the repo owner via OIDC), so this can be a personal account or any org the user has access to.
 
-If any check fails, tell the contributor what's missing and point them to `~/.claude/skills/nimblebrain-contributor/references/DEV_SETUP.md` for setup instructions. Don't block on optional tools (e.g., mpak-scanner) — just note they're unavailable and skip the phases that need them.
+If any check fails, tell the contributor what's missing and point them to `~/.claude/skills/nimblebrain-contributor/references/DEV_SETUP.md` for setup instructions. Don't block on optional tools (e.g., docker) — just note they're unavailable and skip the phases that need them.
 
 ## 0c: Language
 
@@ -108,42 +108,9 @@ Otherwise:
      --template NimbleBrainInc/mcp-server-template-typescript --public --clone
    ```
 
-4. **Immediately after cloning, `cd` into `mcp-<name>` and replace all template placeholders with the actual service name.** Do not move on until this is done — downstream phases assume the project already has correct names everywhere.
-
-**Python template substitutions:**
-
-1. Rename the package directory:
-   ```bash
-   mv src/mcp_example src/mcp_<name>
-   ```
-2. Replace across all files (`*.py`, `*.toml`, `*.json`, `*.md`, `Makefile`, `.env.example`):
-   - `mcp_example` → `mcp_<name>` (package name in imports, paths, logger)
-   - `mcp-example` → `mcp-<name>` (project/bundle name)
-   - `@nimblebraininc/example` → `@<github_owner>/<name>` (registry identifier)
-   - `ExampleClient` → `<Name>Client` (class name)
-   - `ExampleAPIError` → `<Name>APIError` (class name)
-   - `EXAMPLE_API_KEY` → `<NAME>_API_KEY` (env var)
-   - `https://api.example.com/v1` → leave as TODO for Phase 3 to fill with actual API URL
-   - `https://example.com/settings/api` → leave as TODO for Phase 3
-   - `mcp-server-example` → `mcp-server-<name>` (User-Agent)
-   - `FastMCP("Example")` → `FastMCP("<display>")` (server display name)
-   - `"example"` in `pyproject.toml` keywords → `"<name>"`
-   - Update `pyproject.toml` URLs to use `mcp-<name>` repo name
-   - Update README title and description to reference `<display>` instead of "Example"
-
-**TypeScript template substitutions:**
-
-Replace across all files (`*.ts`, `*.json`, `*.md`, `Makefile`, `CLAUDE.md`):
-   - `YOUR_SERVER_NAME` → `<name>`
-   - `YOUR_DISPLAY_NAME` → `<display>`
-   - `YOUR_REPO_NAME` → `mcp-<name>`
-   - `YOUR_API_KEY_ENV_VAR` → `<NAME>_API_KEY`
-   - `YOUR_API_HOST` → leave as TODO for Phase 3
-   - `YOUR_API_BASE_URL` → leave as TODO for Phase 3
-   - `YOUR_GITHUB_USERNAME` → `<github_owner>` (already detected in Phase 0b)
-   - `YOUR_SERVICE` → `<display>`
-
-After substitutions, do a quick sanity check — grep for any remaining `example`/`Example`/`EXAMPLE` (Python) or `YOUR_` (TypeScript) across the project. If any remain, fix them. Then confirm to the user: "Template customized — all placeholder names replaced with `<name>`."
+4. **Immediately after cloning, `cd` into `mcp-<name>` and replace all template
+   placeholders** following the full list in `references/CONVENTIONS-{lang}.md`
+   → "Template Substitutions". Confirm to the user when done.
 
 ## 0g: API Key Readiness
 

--- a/build-mcpb/references/workflow/phase-2-scaffold.md
+++ b/build-mcpb/references/workflow/phase-2-scaffold.md
@@ -4,32 +4,19 @@ Phase 0 created the repo from template and customized all placeholders. Verify t
 
 ## 2a: Verify Structure
 
-**Python** — check that these exist:
-- `src/mcp_<name>/server.py`, `api_client.py`, `api_models.py`, `__init__.py`
-- `tests/`
-- `manifest.json`, `server.json`, `pyproject.toml`, `Makefile`
-- `.github/workflows/ci.yml`, `.github/workflows/build-bundle.yml`
-- `.gitignore`, `.mcpbignore`
+Verify that all expected files exist. The canonical directory structure is defined in:
 
-**TypeScript** — check that these exist:
-- `src/index.ts`, `config.ts`, `constants.ts`, `types.ts`, `schemas.ts`, `formatters.ts`
-- `src/handlers/`, `src/utils/apiClient.ts`, `src/utils/errorResponse.ts`
-- `tests/`
-- `manifest.json`, `server.json`, `package.json`, `tsconfig.json`, `Makefile`
-- `.github/workflows/ci.yml`, `.github/workflows/build-bundle.yml`
-- `.gitignore`, `.mcpbignore`
+`references/PATTERNS-{lang}.md` → "Directory Structure"
 
-If any files are missing, create them following the patterns in `references/PATTERNS.md`.
+If any files are missing, create them from `references/PATTERNS-{lang}.md`.
 
-> **Fallback:** If `.gitignore` is missing (e.g., manual repo without template), generate it using the canonical content from `references/PATTERNS.md`. This prevents build artifacts (`bundle/`, `deps/`, `*.mcpb`), scanner reports, and secrets from being committed.
-
-See `references/PATTERNS.md` for full directory structure reference.
+> **Fallback:** If `.gitignore` is missing (e.g., manual repo without template), generate it using the canonical content from `references/PATTERNS-{lang}.md` → ".gitignore". This prevents build artifacts (`bundle/`, `deps/`, `*.mcpb`), scanner reports, and secrets from being committed.
 
 ## Gate
 
 **Criteria:**
 - [ ] All expected files exist for the chosen language
-- [ ] Any missing files have been created from `references/PATTERNS.md`
+- [ ] Any missing files have been created from `references/PATTERNS-{lang}.md`
 
 **If any criterion fails:** Create missing files before proceeding.
 

--- a/build-mcpb/references/workflow/phase-3-implement-and-verify.md
+++ b/build-mcpb/references/workflow/phase-3-implement-and-verify.md
@@ -4,73 +4,27 @@ Write tool logic, models, and client code, then run all checks to ensure the imp
 
 ## Concept Mapping
 
-| Concept | Python | TypeScript |
-|---------|--------|------------|
-| Response models | Pydantic `BaseModel` | Zod `z.object()` in `types.ts` |
-| Tool input validation | Python type hints + FastMCP | Zod schemas in `schemas.ts` |
-| HTTP client | `aiohttp.ClientSession` | `fetch()` built-in |
-| Tool registration | `@mcp.tool()` decorator | `server.registerTool()` call |
-| Response formatting | Return Pydantic model directly | `formatters.ts` → JSON.stringify |
-| Error handling | `try/except APIError` | `try/catch` → `errorResponse()` |
+See `references/CONVENTIONS-{lang}.md` → "Concept Mapping" for language-specific patterns.
 
-## If Python
+## Implementation
 
-Implement in this order:
-1. **`api_models.py`** — Pydantic models for API responses. Use `Field(alias=...)` for camelCase mapping.
-2. **`api_client.py`** — Async aiohttp client. Set BASE_URL, add one method per endpoint.
-3. **`server.py`** — FastMCP server with `@mcp.tool()` decorators. Global client with lazy init. Dual transport (http_app + stdio).
-4. **`manifest.json`** + **`server.json`** — Fill all placeholder fields. See `references/CONVENTIONS.md` for the full `server.json` schema.
+Implement in the order specified in `references/PATTERNS-{lang}.md` → "Implementation Order".
+See `references/PATTERNS-{lang}.md` for complete code examples.
 
-See `references/PATTERNS.md` → "Python Server Patterns" for complete code examples.
-
-## If TypeScript
-
-Implement in this order:
-1. **`src/types.ts`** — Zod schemas for API response shapes
-2. **`src/utils/apiClient.ts`** — Rename class, set BASE_URL, add methods. Update import in `errorResponse.ts`.
-3. **`src/schemas.ts`** — Zod input schema for each tool
-4. **`src/formatters.ts`** — One formatter per resource type
-5. **`src/handlers/<tool>.ts`** — One file per tool
-6. **`src/index.ts`** — `server.registerTool()` for each tool
-7. **`src/config.ts`** — Rename env var
-8. **`manifest.json`** + **`server.json`** — Fill all TODO fields, then `make sync`
-
-See `references/PATTERNS.md` → "TypeScript Server Patterns" for complete code examples.
-
-## Critical Notes (TypeScript)
-
-- Use **exact dependency versions** (no `^` or `~`) — range specifiers are L2 MTF findings
-- Use `.js` extensions in all imports (Node ESM requirement)
-- Never edit `src/constants.ts` manually — use `make sync`
-- Never edit `.github/workflows/` — shared infrastructure
-- The embedded SKILL.md lives in `src/` and is copied to `build/` during compilation
+For manifest and server.json fields, see `references/CONVENTIONS-{lang}.md`.
 
 ## Verify
 
-Run all checks and fix any issues before proceeding.
+Run all checks and fix any issues before proceeding. See `references/PATTERNS-{lang}.md`
+→ "Build & Test Commands" for the full command set.
 
-**Python:**
-```bash
-uv sync --dev
-make check                    # format, lint, typecheck, unit tests
-make test-integration         # real API calls (needs <NAME>_API_KEY)
-make test-llm                 # LLM smoke tests (needs ANTHROPIC_API_KEY)
-```
-
-The template includes three test layers:
-1. **Unit tests** (`tests/`) — Mocked HTTP, FastMCP Client-based tool tests, skill resource tests. Always run.
-2. **Integration tests** (`tests-integration/`) — Real API calls with tier-skip helpers for plan-gated endpoints. Run when API key is available.
-3. **LLM smoke tests** (`tests-integration/test_skill_llm.py`) — Verify Claude Haiku selects the correct tool given the skill resource. Run when both API key and ANTHROPIC_API_KEY are available.
-
-At minimum, `make check` must pass (unit tests). Integration and LLM tests are recommended but not blocking for initial release.
-
-See `references/PATTERNS.md` → "Test Patterns (Python)" for complete examples including the FastMCP Client pattern, ToolError handling, and tier-skip helpers.
-
-**TypeScript:**
 ```bash
 make check
 ```
-This runs: `format:check` → `lint` → `typecheck` → `test`
+
+**Python only:** Also run `make test-integration` (needs `<NAME>_API_KEY`) and `make test-llm`
+(needs `ANTHROPIC_API_KEY`). Three test layers — see `references/PATTERNS-{lang}.md`
+→ "Test Patterns" for complete examples. At minimum, `make check` must pass.
 
 ## Gate
 

--- a/build-mcpb/references/workflow/phase-4-validate-bundle.md
+++ b/build-mcpb/references/workflow/phase-4-validate-bundle.md
@@ -4,7 +4,7 @@ Validate the manifest, build the project, create the bundle, run MTF compliance 
 
 ## 4a: Manifest Validation
 
-Check `manifest.json` against the mpak registry schema. See `references/CONVENTIONS.md` for the full manifest format per language.
+Check `manifest.json` against the mpak registry schema. See `references/CONVENTIONS-{lang}.md` for the full manifest format.
 
 **Registry validation checklist** (read `manifest.json` and verify each):
 
@@ -20,8 +20,8 @@ Check `manifest.json` against the mpak registry schema. See `references/CONVENTI
    - `sensitive: true` for secrets (API keys, tokens)
    - Referenced via `${user_config.<field>}` in `server.mcp_config.env`
 6. **tools array** — each entry needs `name` (required) and `description` (recommended)
-7. **Python-specific:** `server.type: "python"`, `entry_point` is module path
-8. **TypeScript-specific:** `server.type: "node"`, `entry_point: "build/index.js"`, `${__dirname}` prefix in args
+7. **Language-specific fields:** See `references/CONVENTIONS-{lang}.md` → "Manifest"
+   for `server.type`, `entry_point` format, and runtime-path variables.
 
 **mpak.json check** — verify `mpak.json` exists in repo root with:
 ```json
@@ -37,11 +37,12 @@ This file is required for package claiming on the registry. The `name` must matc
 - **Python:** `uv sync` succeeds, entry point module is importable
 - **TypeScript:** `npm run build` succeeds, `build/index.js` exists
 
+See `references/PATTERNS-{lang}.md` → "Build & Test Commands" for the full set.
+
 ## 4c: Bundle Inspection
 
-- **Python:** `make bundle` (vendors deps into `deps/`, packs with `npx @anthropic-ai/mcpb pack`)
-- **TypeScript:** `make bundle` (builds, prunes dev deps, packs)
-- Both: no accidental large files (.git, node_modules), manifest.json present in bundle root
+Run `make bundle`. See `references/PATTERNS-{lang}.md` → "`bundle` Target" for the Makefile recipe.
+Verify: no large files (`.git`, `node_modules`), `manifest.json` present in bundle root.
 
 ## 4d: MTF Compliance (if mpak-scanner available)
 
@@ -51,19 +52,17 @@ mpak-scanner scan .
 
 ## 4e: Runtime Validation
 
-The MCP protocol requires an initialize handshake before any method calls. Send `initialize`, then `notifications/initialized`, then `tools/list`:
+The MCP protocol requires an initialize handshake before any method calls. Send `initialize`, `notifications/initialized`, `tools/list`. The printf payload is identical — only the executor differs:
 
-**Python:**
+- **Python:** `... | uv run python -m mcp_<name>.server 2>/dev/null`
+- **TypeScript:** `... | node build/index.js --stdio 2>/dev/null`
+
+Full command:
 ```bash
-printf '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized"}\n{"jsonrpc":"2.0","method":"tools/list","id":2}\n' | uv run python -m mcp_<name>.server 2>/dev/null
+printf '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized"}\n{"jsonrpc":"2.0","method":"tools/list","id":2}\n' | <executor> 2>/dev/null
 ```
 
-**TypeScript:**
-```bash
-printf '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized"}\n{"jsonrpc":"2.0","method":"tools/list","id":2}\n' | node build/index.js --stdio 2>/dev/null
-```
-
-Both: server responds with valid JSON-RPC `initialize` result followed by `tools/list` result. No garbage on stdout (logs go to stderr).
+Server responds with valid JSON-RPC `initialize` result followed by `tools/list` result. No garbage on stdout (logs go to stderr).
 
 ## Gate
 

--- a/build-mcpb/references/workflow/phase-5-embed-skill.md
+++ b/build-mcpb/references/workflow/phase-5-embed-skill.md
@@ -4,15 +4,13 @@ Create an in-package skill resource that guides LLMs on how to select and compos
 
 ## 5a: Analyze Tools
 
-Extract the server's tool surface:
-- **Python:** Extract all `@mcp.tool()` functions from `server.py`
-- **TypeScript:** Extract all `server.registerTool()` calls from `src/index.ts`
+Extract all tool registrations from the server entry point.
+See `references/CONVENTIONS-{lang}.md` → "Concept Mapping" for the pattern name.
 
 ## 5b: Draft SKILL.md
 
-Generate a **draft** embedded skill file — or edit the generic scaffolded one, if it exists:
-- **Python:** `src/mcp_<name>/SKILL.md`
-- **TypeScript:** `src/SKILL.md`
+Generate a **draft** embedded skill file — or edit the generic scaffolded one, if it exists.
+See `references/SKILL_FORMAT-{lang}.md` → "File Location" for the correct path.
 
 The draft should contain:
 
@@ -80,36 +78,19 @@ Do **not** proceed to wiring (5d) until the contributor has explicitly approved 
 
 ## 5d: Wire the Resource
 
-**Python:** Add to `server.py`:
-- `from importlib.resources import files` import
-- `SKILL_CONTENT = files("mcp_<name>").joinpath("SKILL.md").read_text()`
-- `instructions=` parameter on `FastMCP(...)` constructor
-- `@mcp.resource("skill://<name>/usage")` decorated function returning `SKILL_CONTENT`
-
-**TypeScript:** Add to `src/index.ts`:
-- `import { readFileSync } from "fs"` and `import { join } from "path"`
-- `const SKILL_CONTENT = readFileSync(join(__dirname, "SKILL.md"), "utf-8")`
-- `instructions` in `McpServer` constructor
-- `server.resource("skill-usage", "skill://<name>/usage", ...)` registration
-
-**TypeScript bundling:** Since `.mcpbignore` excludes both `src/` and `*.md`:
-1. Add to Makefile `build` target: `cp src/SKILL.md build/SKILL.md`
-2. Add to `.mcpbignore`: `!build/SKILL.md`
-
-See `references/SKILL_FORMAT.md` for complete wiring examples in both languages.
+Wire the skill resource per `references/SKILL_FORMAT-{lang}.md` → "Wiring Pattern"
+(TypeScript bundling step included there).
 
 ## 5e: Verify
 
-Run MCP runtime validation (same as Phase 4e) and confirm `resources/list` includes `skill://<name>/usage`:
+Same command as Phase 4e with `resources/list` instead of `tools/list`. Only the executor differs:
 
-**Python:**
-```bash
-printf '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized"}\n{"jsonrpc":"2.0","method":"resources/list","id":2}\n' | uv run python -m mcp_<name>.server 2>/dev/null
-```
+- **Python:** `... | uv run python -m mcp_<name>.server 2>/dev/null`
+- **TypeScript:** `... | node build/index.js --stdio 2>/dev/null`
 
-**TypeScript:**
+Full command:
 ```bash
-printf '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized"}\n{"jsonrpc":"2.0","method":"resources/list","id":2}\n' | node build/index.js --stdio 2>/dev/null
+printf '{"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"0.1.0"}}}\n{"jsonrpc":"2.0","method":"notifications/initialized"}\n{"jsonrpc":"2.0","method":"resources/list","id":2}\n' | <executor> 2>/dev/null
 ```
 
 The response should include a resource with `uri: "skill://<name>/usage"`.

--- a/build-mcpb/references/workflow/phase-6-release.md
+++ b/build-mcpb/references/workflow/phase-6-release.md
@@ -6,13 +6,14 @@ The contributor created and owns the repo — there is no PR to open. The goal i
 
 Before committing, verify the release will succeed:
 
-1. **Version consistency** — Read the version from `manifest.json` and confirm it matches across all version sources:
-   - Python: `pyproject.toml`, `server.json`, `src/mcp_<name>/__init__.py`
-   - TypeScript: run `make sync` and verify no diff
+1. **Version consistency** — Read the version from `manifest.json` and confirm it matches across all version sources.
+   See `references/CONVENTIONS-{lang}.md` → "Version Management" for the files to verify.
    If anything is out of sync, run `make bump VERSION=<version>` to fix.
 2. **`mpak.json`** — Must exist in the repo root with `name` matching `manifest.json`. Without it, the registry announce fails silently after the bundle builds.
 3. **No secrets in working tree** — Check for `.env` files or anything containing real API keys. Warn the contributor if found; do not stage them.
-4. **Skill resource wired** — Verify SKILL.md exists at the expected path (`src/mcp_<name>/SKILL.md` for Python, `src/SKILL.md` for TypeScript) and the resource is registered in server code.
+4. **Skill resource wired** — Verify SKILL.md exists at the expected path
+   (see `references/SKILL_FORMAT-{lang}.md` → "File Location") and the resource
+   is registered in server code.
 
 ## 6b: Stage and Commit
 


### PR DESCRIPTION
## Summary

- Replace three monolithic reference files (`CONVENTIONS.md`, `PATTERNS.md`, `SKILL_FORMAT.md`) with six per-language variants (`-PY.md` / `-TS.md`), each self-contained so the agent loads exactly one language track per invocation
- Update workflow phases 0, 2, 3, 4, 5, 6 to use `{lang}`-parameterized pointers instead of inline A/B branching
- Relocate inline content from workflow phases into the appropriate reference files: template substitutions → CONVENTIONS, concept mapping & critical notes → CONVENTIONS, implementation order → PATTERNS, wiring patterns → SKILL_FORMAT

Closes #60

## Test plan

- [x] `./scripts/validate.sh` passes
- [ ] Verify all `{lang}` references in workflow phases resolve correctly for both PY and TS
- [ ] Spot-check that no content was lost during the split (diff old files against new PY+TS pairs)
- [ ] Confirm no remaining references to the deleted files (`CONVENTIONS.md`, `PATTERNS.md`, `SKILL_FORMAT.md`)